### PR TITLE
Support Perl 5.42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         perl:
           [
+            "5.42",
             "5.40",
             "5.38",
             "5.36",
@@ -25,8 +26,10 @@ jobs:
             "5.10",
           ]
         include:
-          - perl: 5.40
+          - perl: 5.42
             coverage_test: true
+            external_test: true
+          - perl: 5.40
             external_test: true
           - perl: 5.38
             external_test: true


### PR DESCRIPTION
## Summary

- Add Perl 5.42 to the CI test matrix
- Move coverage testing to Perl 5.42 (latest version)
- Keep external_test enabled for 5.40 and 5.38

## Test plan

- [ ] Verify CI runs successfully on Perl 5.42
- [ ] Verify coverage reports are generated correctly

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)